### PR TITLE
[001]-feed write and feedLike

### DIFF
--- a/src/main/java/B4F2/PetStagram/exception/ErrorCode.java
+++ b/src/main/java/B4F2/PetStagram/exception/ErrorCode.java
@@ -14,7 +14,12 @@ public enum ErrorCode {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST,"잘못된 아이디(이메일)입니다"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST,"잘못된 패스워드입니다"),
 
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당 유저를 찾을 수 없습니다")
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당 유저를 찾을 수 없습니다"),
+
+
+    //Feed 돤련 오류
+    NOT_FOUND_BOARD(HttpStatus.BAD_REQUEST, "해당 게시물을 찾을 수 없습니다."),
+    WRONG_APPROACH(HttpStatus.BAD_REQUEST,"잘못된 접근 방법입니다.")
 
 
     ;

--- a/src/main/java/B4F2/PetStagram/feed/controller/FCtest.java
+++ b/src/main/java/B4F2/PetStagram/feed/controller/FCtest.java
@@ -1,4 +1,0 @@
-package B4F2.PetStagram.feed.controller;
-
-public class FCtest {
-}

--- a/src/main/java/B4F2/PetStagram/feed/controller/FeedController.java
+++ b/src/main/java/B4F2/PetStagram/feed/controller/FeedController.java
@@ -1,0 +1,32 @@
+package B4F2.PetStagram.feed.controller;
+
+import B4F2.PetStagram.feed.domain.WriteFeed;
+import B4F2.PetStagram.feed.service.FeedService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/feed")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedService feedService;
+
+    @PostMapping("/write")
+    public ResponseEntity<?> writeFeed(@RequestBody WriteFeed.Request writeFeed, Authentication auth){
+
+        return ResponseEntity.ok(feedService.writeFeed(writeFeed, auth.getName()));
+
+    }
+
+    @GetMapping("/like")
+    public boolean likeFeed(@RequestParam Long feedId) {
+
+        return feedService.likeFeed(feedId);
+    }
+
+}

--- a/src/main/java/B4F2/PetStagram/feed/domain/WriteFeed.java
+++ b/src/main/java/B4F2/PetStagram/feed/domain/WriteFeed.java
@@ -1,0 +1,45 @@
+package B4F2.PetStagram.feed.domain;
+
+import B4F2.PetStagram.feed.entity.FeedEntity;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class WriteFeed {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private String mainText;
+
+        public FeedEntity toEntity(String userId) {
+            return FeedEntity.builder()
+                    .userId(userId)
+                    .mainText(mainText)
+                    .updateDit(LocalDateTime.now())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        private String userId;
+        private String mainText;
+
+        public Response form(String userId, String mainText){
+            return Response.builder()
+                    .userId(userId)
+                    .mainText(mainText)
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/B4F2/PetStagram/feed/entity/FeedEntity.java
+++ b/src/main/java/B4F2/PetStagram/feed/entity/FeedEntity.java
@@ -1,0 +1,30 @@
+package B4F2.PetStagram.feed.entity;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "Feed")
+public class FeedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String mainText;
+    private String userId;
+    private LocalDateTime updateDit;
+    private Integer like;
+
+    // 업로드 사진
+}

--- a/src/main/java/B4F2/PetStagram/feed/repository/FRtest.java
+++ b/src/main/java/B4F2/PetStagram/feed/repository/FRtest.java
@@ -1,4 +1,0 @@
-package B4F2.PetStagram.feed.repository;
-
-public class FRtest {
-}

--- a/src/main/java/B4F2/PetStagram/feed/repository/FeedRepository.java
+++ b/src/main/java/B4F2/PetStagram/feed/repository/FeedRepository.java
@@ -1,0 +1,19 @@
+package B4F2.PetStagram.feed.repository;
+
+import B4F2.PetStagram.feed.entity.FeedEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedRepository extends JpaRepository<FeedEntity, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Feed f set f.like = :likeCnt where f.id = :feedId")
+    void likeFeed(Long likeCnt, Long feedId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Feed f set f.like = :likeCnt where f.id = :feedId")
+    void unLikeFeed(Long likeCnt, Long feedId);
+}

--- a/src/main/java/B4F2/PetStagram/feed/service/FStest.java
+++ b/src/main/java/B4F2/PetStagram/feed/service/FStest.java
@@ -1,4 +1,0 @@
-package B4F2.PetStagram.feed.service;
-
-public class FStest {
-}

--- a/src/main/java/B4F2/PetStagram/feed/service/FeedService.java
+++ b/src/main/java/B4F2/PetStagram/feed/service/FeedService.java
@@ -1,0 +1,60 @@
+package B4F2.PetStagram.feed.service;
+
+import B4F2.PetStagram.exception.CustomException;
+import B4F2.PetStagram.exception.ErrorCode;
+import B4F2.PetStagram.feed.domain.WriteFeed;
+import B4F2.PetStagram.feed.entity.FeedEntity;
+import B4F2.PetStagram.feed.repository.FeedRepository;
+import B4F2.PetStagram.member.entity.Member;
+import B4F2.PetStagram.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+
+    private final MemberRepository memberRepository;
+    public WriteFeed.Response writeFeed(WriteFeed.Request writeFeed, String userId) {
+
+        Member member = memberRepository.findByEmail(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        feedRepository.save(writeFeed.toEntity(userId));
+
+        return new WriteFeed.Response(userId, writeFeed.getMainText());
+    }
+
+    public boolean likeFeed(Long feedId) {
+        FeedEntity feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOARD));
+
+        Long likeCnt = feed.getLike() + 1L;
+
+        feedRepository.likeFeed(likeCnt,feedId);
+
+        return true;
+    }
+
+    public boolean unLikeFeed(Long feedId) {
+
+        FeedEntity feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOARD));
+
+        Long likeCnt;
+
+        if (feed.getLike() < 0) {
+            throw  new CustomException(ErrorCode.WRONG_APPROACH);
+        } else {
+            likeCnt = feed.getLike() - 1L;
+        }
+
+        feedRepository.unLikeFeed(likeCnt,feedId);
+
+        return true;
+    }
+}


### PR DESCRIPTION
[001]-feed write and feedLike

기본적인 게시물 작성과 게시물에 대한 좋아요, 좋아요 취소 기능구현

1. 로그인 된 유저의 userid(Email)와 본문 내용을 받아와서 기본적인 게시물을 작성 기능
2. 해당 게시물에 대한 좋아요 기능과 좋아요 취소 기능

위 2가지 기능을 구현했습니다. 
추후 게시물 작성에는 사진 업로드를 같이 올리면 될 것 같습니다. 