### PR TITLE
Tag regis

### DIFF
--- a/src/main/java/B4F2/PetStagram/exception/ErrorCode.java
+++ b/src/main/java/B4F2/PetStagram/exception/ErrorCode.java
@@ -14,7 +14,12 @@ public enum ErrorCode {
     INVALID_EMAIL(HttpStatus.BAD_REQUEST,"잘못된 아이디(이메일)입니다"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST,"잘못된 패스워드입니다"),
 
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당 유저를 찾을 수 없습니다")
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST,"해당 유저를 찾을 수 없습니다"),
+
+
+    //Feed 돤련 오류
+    NOT_FOUND_BOARD(HttpStatus.BAD_REQUEST, "해당 게시물을 찾을 수 없습니다."),
+    WRONG_APPROACH(HttpStatus.BAD_REQUEST,"잘못된 접근 방법입니다.")
 
 
     ;

--- a/src/main/java/B4F2/PetStagram/feed/controller/FCtest.java
+++ b/src/main/java/B4F2/PetStagram/feed/controller/FCtest.java
@@ -1,4 +1,0 @@
-package B4F2.PetStagram.feed.controller;
-
-public class FCtest {
-}

--- a/src/main/java/B4F2/PetStagram/feed/controller/FeedController.java
+++ b/src/main/java/B4F2/PetStagram/feed/controller/FeedController.java
@@ -23,10 +23,22 @@ public class FeedController {
 
     }
 
+    @DeleteMapping("/delete")
+    public boolean deleteFeed(@RequestParam Long feedId, Authentication auth) {
+
+        return feedService.deleteFeed(feedId, auth.getName());
+    }
+
     @GetMapping("/like")
     public boolean likeFeed(@RequestParam Long feedId) {
 
         return feedService.likeFeed(feedId);
+    }
+
+    @GetMapping("/unlike")
+    public boolean unLikeFeed(@RequestParam Long feedId) {
+
+        return feedService.unLikeFeed(feedId);
     }
 
 }

--- a/src/main/java/B4F2/PetStagram/feed/controller/FeedController.java
+++ b/src/main/java/B4F2/PetStagram/feed/controller/FeedController.java
@@ -1,0 +1,32 @@
+package B4F2.PetStagram.feed.controller;
+
+import B4F2.PetStagram.feed.domain.WriteFeed;
+import B4F2.PetStagram.feed.service.FeedService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/feed")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedService feedService;
+
+    @PostMapping("/write")
+    public ResponseEntity<?> writeFeed(@RequestBody WriteFeed.Request writeFeed, Authentication auth){
+
+        return ResponseEntity.ok(feedService.writeFeed(writeFeed, auth.getName()));
+
+    }
+
+    @GetMapping("/like")
+    public boolean likeFeed(@RequestParam Long feedId) {
+
+        return feedService.likeFeed(feedId);
+    }
+
+}

--- a/src/main/java/B4F2/PetStagram/feed/controller/FeedController.java
+++ b/src/main/java/B4F2/PetStagram/feed/controller/FeedController.java
@@ -2,6 +2,7 @@ package B4F2.PetStagram.feed.controller;
 
 import B4F2.PetStagram.feed.domain.WriteFeed;
 import B4F2.PetStagram.feed.service.FeedService;
+import B4F2.PetStagram.tag.service.TagService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class FeedController {
 
     private final FeedService feedService;
+
 
     @PostMapping("/write")
     public ResponseEntity<?> writeFeed(@RequestBody WriteFeed.Request writeFeed, Authentication auth){

--- a/src/main/java/B4F2/PetStagram/feed/domain/WriteFeed.java
+++ b/src/main/java/B4F2/PetStagram/feed/domain/WriteFeed.java
@@ -1,0 +1,45 @@
+package B4F2.PetStagram.feed.domain;
+
+import B4F2.PetStagram.feed.entity.FeedEntity;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class WriteFeed {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+        private String mainText;
+
+        public FeedEntity toEntity(String userId) {
+            return FeedEntity.builder()
+                    .userId(userId)
+                    .mainText(mainText)
+                    .updateDit(LocalDateTime.now())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Response {
+
+        private String userId;
+        private String mainText;
+
+        public Response form(String userId, String mainText){
+            return Response.builder()
+                    .userId(userId)
+                    .mainText(mainText)
+                    .build();
+        }
+    }
+
+}

--- a/src/main/java/B4F2/PetStagram/feed/entity/FeedEntity.java
+++ b/src/main/java/B4F2/PetStagram/feed/entity/FeedEntity.java
@@ -1,0 +1,30 @@
+package B4F2.PetStagram.feed.entity;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "Feed")
+public class FeedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String mainText;
+    private String userId;
+    private LocalDateTime updateDit;
+    private Integer like;
+
+    // 업로드 사진
+}

--- a/src/main/java/B4F2/PetStagram/feed/entity/FeedEntity.java
+++ b/src/main/java/B4F2/PetStagram/feed/entity/FeedEntity.java
@@ -2,11 +2,10 @@ package B4F2.PetStagram.feed.entity;
 
 import lombok.*;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import javax.xml.stream.events.Comment;
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 @Getter
@@ -15,16 +14,24 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 @Entity(name = "Feed")
-public class FeedEntity {
+public class FeedEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long feedId;
 
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String mainText;
+
     private String userId;
+
     private LocalDateTime updateDit;
+
     private Integer like;
+
+//    차후 comment 파트와 함께 merge 되면 추가
+//    @OneToMany
+//    private List<CommentEntity> comments;
 
     // 업로드 사진
 }

--- a/src/main/java/B4F2/PetStagram/feed/repository/FRtest.java
+++ b/src/main/java/B4F2/PetStagram/feed/repository/FRtest.java
@@ -1,4 +1,0 @@
-package B4F2.PetStagram.feed.repository;
-
-public class FRtest {
-}

--- a/src/main/java/B4F2/PetStagram/feed/repository/FeedRepository.java
+++ b/src/main/java/B4F2/PetStagram/feed/repository/FeedRepository.java
@@ -1,0 +1,19 @@
+package B4F2.PetStagram.feed.repository;
+
+import B4F2.PetStagram.feed.entity.FeedEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedRepository extends JpaRepository<FeedEntity, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Feed f set f.like = :likeCnt where f.id = :feedId")
+    void likeFeed(Long likeCnt, Long feedId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Feed f set f.like = :likeCnt where f.id = :feedId")
+    void unLikeFeed(Long likeCnt, Long feedId);
+}

--- a/src/main/java/B4F2/PetStagram/feed/service/FStest.java
+++ b/src/main/java/B4F2/PetStagram/feed/service/FStest.java
@@ -1,4 +1,0 @@
-package B4F2.PetStagram.feed.service;
-
-public class FStest {
-}

--- a/src/main/java/B4F2/PetStagram/feed/service/FeedService.java
+++ b/src/main/java/B4F2/PetStagram/feed/service/FeedService.java
@@ -7,6 +7,7 @@ import B4F2.PetStagram.feed.entity.FeedEntity;
 import B4F2.PetStagram.feed.repository.FeedRepository;
 import B4F2.PetStagram.member.entity.Member;
 import B4F2.PetStagram.member.repository.MemberRepository;
+import B4F2.PetStagram.tag.service.TagService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,12 +20,17 @@ public class FeedService {
     private final FeedRepository feedRepository;
 
     private final MemberRepository memberRepository;
+
+    private final TagService tagService;
+
     public WriteFeed.Response writeFeed(WriteFeed.Request writeFeed, String userId) {
 
         Member member = memberRepository.findByEmail(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        feedRepository.save(writeFeed.toEntity(userId));
+        FeedEntity feed = feedRepository.save(writeFeed.toEntity(userId));
+
+        tagService.regisTag(feed);
 
         return new WriteFeed.Response(userId, writeFeed.getMainText());
     }

--- a/src/main/java/B4F2/PetStagram/feed/service/FeedService.java
+++ b/src/main/java/B4F2/PetStagram/feed/service/FeedService.java
@@ -1,0 +1,60 @@
+package B4F2.PetStagram.feed.service;
+
+import B4F2.PetStagram.exception.CustomException;
+import B4F2.PetStagram.exception.ErrorCode;
+import B4F2.PetStagram.feed.domain.WriteFeed;
+import B4F2.PetStagram.feed.entity.FeedEntity;
+import B4F2.PetStagram.feed.repository.FeedRepository;
+import B4F2.PetStagram.member.entity.Member;
+import B4F2.PetStagram.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+
+    private final MemberRepository memberRepository;
+    public WriteFeed.Response writeFeed(WriteFeed.Request writeFeed, String userId) {
+
+        Member member = memberRepository.findByEmail(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        feedRepository.save(writeFeed.toEntity(userId));
+
+        return new WriteFeed.Response(userId, writeFeed.getMainText());
+    }
+
+    public boolean likeFeed(Long feedId) {
+        FeedEntity feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOARD));
+
+        Long likeCnt = feed.getLike() + 1L;
+
+        feedRepository.likeFeed(likeCnt,feedId);
+
+        return true;
+    }
+
+    public boolean unLikeFeed(Long feedId) {
+
+        FeedEntity feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOARD));
+
+        Long likeCnt;
+
+        if (feed.getLike() < 0) {
+            throw  new CustomException(ErrorCode.WRONG_APPROACH);
+        } else {
+            likeCnt = feed.getLike() - 1L;
+        }
+
+        feedRepository.unLikeFeed(likeCnt,feedId);
+
+        return true;
+    }
+}

--- a/src/main/java/B4F2/PetStagram/feed/service/FeedService.java
+++ b/src/main/java/B4F2/PetStagram/feed/service/FeedService.java
@@ -29,6 +29,16 @@ public class FeedService {
         return new WriteFeed.Response(userId, writeFeed.getMainText());
     }
 
+    public boolean deleteFeed(Long feedId, String name) {
+
+        feedRepository.findById(feedId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOARD));
+
+        feedRepository.deleteById(feedId);
+
+        return true;
+    }
+
     public boolean likeFeed(Long feedId) {
         FeedEntity feed = feedRepository.findById(feedId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_BOARD));

--- a/src/main/java/B4F2/PetStagram/tag/controller/TagController.java
+++ b/src/main/java/B4F2/PetStagram/tag/controller/TagController.java
@@ -1,0 +1,18 @@
+package B4F2.PetStagram.tag.controller;
+
+import B4F2.PetStagram.tag.domain.TagDto;
+import B4F2.PetStagram.tag.service.TagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/tag")
+@RequiredArgsConstructor
+public class TagController {
+
+}

--- a/src/main/java/B4F2/PetStagram/tag/domain/TagDto.java
+++ b/src/main/java/B4F2/PetStagram/tag/domain/TagDto.java
@@ -1,0 +1,23 @@
+package B4F2.PetStagram.tag.domain;
+
+import B4F2.PetStagram.tag.entity.TagEntity;
+import lombok.*;
+
+public class TagDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @RequiredArgsConstructor
+    @Builder
+    public static class regisTagDto {
+
+        public TagEntity toEntity(String tag, Long feedId) {
+            return TagEntity.builder()
+                    .tagTitle(tag)
+                    .tagInFeed(feedId)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/B4F2/PetStagram/tag/entity/TagEntity.java
+++ b/src/main/java/B4F2/PetStagram/tag/entity/TagEntity.java
@@ -1,0 +1,37 @@
+package B4F2.PetStagram.tag.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "tag")
+public class TagEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String tagTitle;
+    //tag 에 속해 있는 게시물 id
+    private Long tagInFeed;
+
+    @CreatedDate
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate;
+
+
+}
+

--- a/src/main/java/B4F2/PetStagram/tag/repository/TagRepository.java
+++ b/src/main/java/B4F2/PetStagram/tag/repository/TagRepository.java
@@ -1,0 +1,12 @@
+package B4F2.PetStagram.tag.repository;
+
+import B4F2.PetStagram.tag.entity.TagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TagRepository extends JpaRepository<TagEntity, Long> {
+
+
+
+}

--- a/src/main/java/B4F2/PetStagram/tag/service/TagService.java
+++ b/src/main/java/B4F2/PetStagram/tag/service/TagService.java
@@ -1,0 +1,33 @@
+package B4F2.PetStagram.tag.service;
+
+import B4F2.PetStagram.feed.entity.FeedEntity;
+import B4F2.PetStagram.tag.domain.TagDto;
+import B4F2.PetStagram.tag.repository.TagRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TagService {
+
+    private final TagRepository tagRepository;
+
+    private final Character tagChar = '#';
+
+    public void regisTag(FeedEntity feed) {
+
+        String[] tagList = feed.getMainText().split(" ");
+
+        for(String a : tagList) {
+            if (a.charAt(0) == tagChar) {
+                tagRepository.save(new TagDto.regisTagDto().toEntity(a.substring(1), feed.getFeedId()));
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
Motivation🤔

게시글의 등록을 통한 태그 등록을 기본적 기능으로 구현 해놓았습니다.
현재 저희가 생각했던 정책으로 띄어쓰기 기준으로 '#' 태그가 붙은 단어를 태그로 지정하는 로직을 적용했습니다.
흐름을 간단하게 설명드리면
본문의 내용을 사용자가 작성합니다.
본문의 내용을 내부 함수에 의해서 띄어쓰기 기준으로 split한 후 String array로 저장합니다.
이후 for 문을 통하여 문자열마다 첫 글자가 '#' 인지 검사 후 맞다면 '#'을 제거 한 후 tagRepo에 저장이 됩니다.
저장 될 때는 해당 글이 작성된 FeedId 와 함께 저장이 됩니다.

Key Changes 🔑

To Reviewers 🙏

현재 기본적인 기능을 생각나는 대로 구현 해둔거라 개선사항이 많다고 생각합니다.
위의 방법으로 계속해서 새로운 태그를 등록하다보면 같은 태그라도 작성 된 글이 다르면 또 새로운 태그로 인식하여 저장되는 문제가 있습니다.
그리고 본문의 글이 길어질 경우 띄어쓰기를 기준으로 모든 단어를 저장 했다가 하나하나 검사 해야하는 방식은 효율성면에서 많이 떨어진다고 생각합니다.

개선 방안이 떠오르시면 말씀 해주시면 감사하겠습니다.

